### PR TITLE
fix: GitHub Actions環境設定エラーの修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Environment configuration
+APP_ENV=dev
+APP_SECRET=your-secret-key-here
+
+# Content source URL (replace with your actual source)
+CONTENT_SOURCE_URL=https://dummyjson.com/products
+
+# RSS Feed Configuration
+RSS_TITLE="Generic RSS Feed"
+RSS_DESCRIPTION="Generated RSS feed from content source"
+RSS_LINK="https://example.com"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,12 +31,10 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-dev
 
+    - name: Copy environment file
+      run: cp .env.example .env
+
     - name: Generate RSS Feed
-      env:
-        CONTENT_SOURCE_URL: ${{ secrets.CONTENT_SOURCE_URL || 'https://api.example.com/changelog' }}
-        RSS_TITLE: ${{ vars.RSS_TITLE || 'Generated RSS Feed' }}
-        RSS_DESCRIPTION: ${{ vars.RSS_DESCRIPTION || 'Automatically generated RSS feed' }}
-        RSS_LINK: ${{ vars.RSS_LINK || 'https://example.com' }}
       run: php bin/console generate-rss
 
     - name: Setup Pages


### PR DESCRIPTION
## Summary
- GitHub Actionsで発生していた`api.example.com`への接続エラーを修正
- `.env.example`ファイルを作成してテンプレート環境設定を提供
- ワークフローでsecrets/varsの代わりに.env.exampleを使用するよう変更

## 修正内容
- `.env.example`ファイルを新規作成
  - 有効なAPIエンドポイント（`https://dummyjson.com/products`）をデフォルト設定
  - テンプレートプロジェクトとして再利用可能な設定
- `.github/workflows/deploy.yml`の変更
  - secrets/varsによる環境変数設定を削除
  - `.env.example`をコピーして環境設定を使用

## Test plan
- [x] ローカル環境でRSS生成が正常動作することを確認
- [ ] GitHub Actionsワークフローが正常実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)