### PR TITLE
fix: ワークフローをPR必須制約に対応 (公式ツールのみ使用)

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -42,7 +42,29 @@ jobs:
     - name: Generate RSS Feed
       run: composer generate-rss
 
-    - name: Commit and push changes
-      uses: stefanzweifel/git-auto-commit-action@v5
+    - name: Check for changes
+      id: changes
+      run: |
+        if [[ -n $(git status --porcelain) ]]; then
+          echo "changes=true" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
+        else
+          echo "changes=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create Pull Request
+      if: steps.changes.outputs.changes == 'true'
+      uses: peter-evans/create-pull-request@v7
       with:
-        commit_message: RSS feed updated
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: RSS feed updated
+        title: 'RSS feed updated - ${{ steps.changes.outputs.timestamp }}'
+        body: |
+          Automated RSS feed update
+          
+          - Generated RSS from latest content source
+          - Updated feed.xml with new timestamps
+          
+          🤖 Generated automatically by GitHub Actions
+        branch: rss-update-${{ steps.changes.outputs.timestamp }}
+        delete-branch: true

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -42,29 +42,22 @@ jobs:
     - name: Generate RSS Feed
       run: composer generate-rss
 
-    - name: Check for changes
-      id: changes
+    - name: Create and merge PR if changes exist
       run: |
         if [[ -n $(git status --porcelain) ]]; then
-          echo "changes=true" >> $GITHUB_OUTPUT
-          echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
-        else
-          echo "changes=false" >> $GITHUB_OUTPUT
-        fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          timestamp=$(date +%Y%m%d-%H%M%S)
+          branch="rss-update-$timestamp"
+          git checkout -b $branch
+          git add .
+          git commit -m "RSS feed updated"
+          git push origin $branch
+          gh pr create --title "RSS feed updated - $timestamp" --body "Automated RSS feed update
 
-    - name: Create Pull Request
-      if: steps.changes.outputs.changes == 'true'
-      uses: peter-evans/create-pull-request@v7
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: RSS feed updated
-        title: 'RSS feed updated - ${{ steps.changes.outputs.timestamp }}'
-        body: |
-          Automated RSS feed update
-          
           - Generated RSS from latest content source
           - Updated feed.xml with new timestamps
-          
-          🤖 Generated automatically by GitHub Actions
-        branch: rss-update-${{ steps.changes.outputs.timestamp }}
-        delete-branch: true
+
+          🤖 Generated automatically by GitHub Actions" --head $branch
+          gh pr merge --auto --squash
+        fi


### PR DESCRIPTION
## Summary
リポジトリのPR必須設定に対応し、サプライチェーン攻撃対策として公式ツールのみを使用

## 問題
- GitHub Actionsワークフローからのmainブランチへの直接pushが拒否される
- リポジトリでPull Request必須ルールが設定されている
- サプライチェーン攻撃対策として非公式アクションを避けたい

## 解決策
- GitHub CLI (`gh`) のみを使用してPR作成・自動マージ
- 変更検知から自動マージまでを一つのステップで実行
- タイムスタンプベースのブランチ名でコンフリクトを回避

## 動作
1. RSS生成を実行
2. 変更があるかチェック
3. 変更があれば:
   - 新しいブランチを作成
   - 変更をコミット・プッシュ
   - PRを作成
   - 自動マージを有効化

🤖 Generated with [Claude Code](https://claude.ai/code)