### PR TITLE
fix: GitHub CLIにGH_TOKEN環境変数を追加

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -43,6 +43,8 @@ jobs:
       run: composer generate-rss
 
     - name: Create and merge PR if changes exist
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         if [[ -n $(git status --porcelain) ]]; then
           git config user.name github-actions[bot]


### PR DESCRIPTION
GitHub Actionsワークフロー内でGitHub CLIを使用するために必要な環境変数を追加

🤖 Generated with [Claude Code](https://claude.ai/code)